### PR TITLE
Lock jquery-rails at 4.0.4 because of regression

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "decent_exposure"
 gem "draper"
 gem "faker"
 gem "jquery-datatables-rails"
-gem "jquery-rails"
+gem "jquery-rails", "4.0.4" # version 4.0.5 breaks jquery-datatables
 gem "liquid"
 gem "lograge"
 gem "netguru_theme"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,7 +160,7 @@ GEM
       jquery-rails
       railties (>= 3.1)
       sass-rails
-    jquery-rails (4.0.5)
+    jquery-rails (4.0.4)
       rails-dom-testing (~> 1.0)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
@@ -420,7 +420,7 @@ DEPENDENCIES
   guard-rubocop
   hub
   jquery-datatables-rails
-  jquery-rails
+  jquery-rails (= 4.0.4)
   launchy
   letter_opener
   liquid


### PR DESCRIPTION
jquery-rails version 4.0.5 breaks jquery-datatables
https://github.com/rweng/jquery-datatables-rails/issues/198