### PR TITLE
Feature/supervisor slack notifications

### DIFF
--- a/app/controllers/reminders_controller.rb
+++ b/app/controllers/reminders_controller.rb
@@ -68,6 +68,7 @@ class RemindersController < ApplicationController
   def reminder_attrs
     params.require(:reminder)
           .permit(:name, :valid_for_n_days, :remind_after_days,
-                  :notification_text, :deadline_text, :slack_channel)
+                  :notification_text, :deadline_text, :slack_channel,
+                  :supervisor_slack_channel)
   end
 end

--- a/app/decorators/check_assignment_decorator.rb
+++ b/app/decorators/check_assignment_decorator.rb
@@ -26,4 +26,9 @@ class CheckAssignmentDecorator < Draper::Decorator
   def assigned_days_ago_as_string
     "#{h.time_ago_in_words(object.created_at)} ago"
   end
+
+  def completion_notification_text(checker)
+    "#{checker.name} has completed #{object.project_check.reminder.name} " \
+      "in #{object.project_check.project.name}: #{object.note_url}"
+  end
 end

--- a/app/decorators/project_check_decorator.rb
+++ b/app/decorators/project_check_decorator.rb
@@ -102,11 +102,6 @@ class ProjectCheckDecorator < Draper::Decorator
     object.reminder.supervisor_slack_channel
   end
 
-  def completion_notification_text(checker)
-    "#{checker.name} has completed #{object.reminder.name} " \
-      "in #{object.project.name}."
-  end
-
   private
 
   def reviewer_deadline(days_left)

--- a/app/decorators/project_check_decorator.rb
+++ b/app/decorators/project_check_decorator.rb
@@ -103,7 +103,8 @@ class ProjectCheckDecorator < Draper::Decorator
   end
 
   def completion_notification_text(checker)
-    "#{checker.name} has completed #{object.reminder.name} in #{object.project.name}."
+    "#{checker.name} has completed #{object.reminder.name} " \
+      "in #{object.project.name}."
   end
 
   private

--- a/app/decorators/project_check_decorator.rb
+++ b/app/decorators/project_check_decorator.rb
@@ -98,6 +98,14 @@ class ProjectCheckDecorator < Draper::Decorator
     object.reminder.slack_channel || object.project.channel_name
   end
 
+  def supervisor_slack_channel
+    object.reminder.supervisor_slack_channel
+  end
+
+  def completion_notification_text(checker)
+    "#{checker.name} has completed #{object.reminder.name} in #{object.project.name}."
+  end
+
   private
 
   def reviewer_deadline(days_left)

--- a/app/decorators/reminder_decorator/base.rb
+++ b/app/decorators/reminder_decorator/base.rb
@@ -1,7 +1,7 @@
 module ReminderDecorator
   class Base < Draper::Decorator
     delegate :id, :name, :valid_for_n_days, :deadline_text, :notification_text,
-             :persisted?, :slack_channel
+             :persisted?, :slack_channel, :supervisor_slack_channel
     decorates :reminder
 
     def remind_after_days
@@ -18,11 +18,17 @@ module ReminderDecorator
     end
 
     def slack_channel_display
-      if slack_channel.present?
-        slack_channel
-      else
-        "Not specified."
-      end
+      slack_channel.presence || not_specified
+    end
+
+    def supervisor_slack_channel_display
+      supervisor_slack_channel.presence || not_specified
+    end
+
+    private
+
+    def not_specified
+      "Not specified."
     end
   end
 end

--- a/app/models/reminder.rb
+++ b/app/models/reminder.rb
@@ -7,4 +7,8 @@ class Reminder < ActiveRecord::Base
   has_many :projects, through: :project_checks
   has_many :check_assignments, through: :project_checks, dependent: :destroy
   has_many :skills, dependent: :destroy
+
+  def notify_supervisor?
+    supervisor_slack_channel.present?
+  end
 end

--- a/app/use_cases/check_assignments/assign_person.rb
+++ b/app/use_cases/check_assignments/assign_person.rb
@@ -30,7 +30,8 @@ module CheckAssignments
       reminder = check.reminder.name
       project = check.project.name
 
-      "#{person.name} got assigned to do next #{reminder} in #{project}. They were notified by email."
+      "#{person.name} got assigned to do next #{reminder} in #{project}. " \
+        "They were notified by email."
     end
 
     def notify_channel(message)

--- a/app/use_cases/check_assignments/assign_person.rb
+++ b/app/use_cases/check_assignments/assign_person.rb
@@ -30,7 +30,7 @@ module CheckAssignments
       reminder = check.reminder.name
       project = check.project.name
 
-      "#{person.name} got assigned to do next #{reminder} in #{project}. "
+      "#{person.name} got assigned to do next #{reminder} in #{project}. They were notified by email."
     end
 
     def notify_channel(message)

--- a/app/use_cases/check_assignments/complete.rb
+++ b/app/use_cases/check_assignments/complete.rb
@@ -35,10 +35,9 @@ module CheckAssignments
 
     def notify_supervisor_channel
       return unless project_check.reminder.notify_supervisor?
-      decorated = project_check.decorate
       CheckAssignments::Notify.new.call(
-        decorated.supervisor_slack_channel,
-        decorated.completion_notification_text(checker),
+        project_check.decorate.supervisor_slack_channel,
+        assignment.decorate.completion_notification_text(checker),
       )
     end
   end

--- a/app/use_cases/check_assignments/complete.rb
+++ b/app/use_cases/check_assignments/complete.rb
@@ -30,13 +30,16 @@ module CheckAssignments
         last_check_date: assignment.completion_date,
         last_check_user_id: checker.id,
       )
-      if project_check.reminder.notify_supervisor?
-        decorated = project_check.decorate
-        CheckAssignments::Notify.new.call(
-          decorated.supervisor_slack_channel,
-          decorated.completion_notification_text(checker),
-        )
-      end
+      notify_supervisor_channel
+    end
+
+    def notify_supervisor_channel
+      return unless project_check.reminder.notify_supervisor?
+      decorated = project_check.decorate
+      CheckAssignments::Notify.new.call(
+        decorated.supervisor_slack_channel,
+        decorated.completion_notification_text(checker),
+      )
     end
   end
 end

--- a/app/use_cases/check_assignments/notify.rb
+++ b/app/use_cases/check_assignments/notify.rb
@@ -23,8 +23,7 @@ module CheckAssignments
     end
 
     def slack_message(message)
-      "Just letting know that " + message +
-        " They were notified by email."
+      "Just letting you know that " + message
     end
 
     def unsuccessful_notification(message)

--- a/app/views/reminders/_form.slim
+++ b/app/views/reminders/_form.slim
@@ -8,6 +8,7 @@
         = f.input :valid_for_n_days
         = f.input :remind_after_days
         = f.input :slack_channel, hint: "If present, all slack notifications, instead of going to project's channel, will go to specified channel.", required: false
+        = f.input :supervisor_slack_channel, hint: "If present, slack notifications for completed assignments will go to this channel.", required: false
         = f.input :deadline_text, as: :text
         = f.input :notification_text, as: :text
 

--- a/app/views/reminders/show.slim
+++ b/app/views/reminders/show.slim
@@ -8,6 +8,7 @@
           th Valid for N days
           th Remind after N days
           th Slack Channel
+          th Supervisor Channel
       tbody
         tr
           td
@@ -16,6 +17,8 @@
             = reminder.remind_after_days
           td
             = reminder.slack_channel_display
+          td
+            = reminder.supervisor_slack_channel_display
 
     .btn-group
       = link_to "Back", reminders_path, class: "btn btn-default"

--- a/db/migrate/20160428070617_add_supervisor_slack_channel_to_reminders.rb
+++ b/db/migrate/20160428070617_add_supervisor_slack_channel_to_reminders.rb
@@ -1,0 +1,5 @@
+class AddSupervisorSlackChannelToReminders < ActiveRecord::Migration
+  def change
+    add_column :reminders, :supervisor_slack_channel, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160418185723) do
+ActiveRecord::Schema.define(version: 20160428070617) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -57,13 +57,14 @@ ActiveRecord::Schema.define(version: 20160418185723) do
 
   create_table "reminders", force: :cascade do |t|
     t.string   "name"
-    t.datetime "created_at",                     null: false
-    t.datetime "updated_at",                     null: false
-    t.integer  "valid_for_n_days",  default: 30
-    t.text     "remind_after_days", default: [],              array: true
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
+    t.integer  "valid_for_n_days",         default: 30
+    t.text     "remind_after_days",        default: [],              array: true
     t.string   "deadline_text"
     t.string   "notification_text"
     t.string   "slack_channel"
+    t.string   "supervisor_slack_channel"
   end
 
   create_table "skills", force: :cascade do |t|

--- a/spec/decorators/reminder_decorator/base_spec.rb
+++ b/spec/decorators/reminder_decorator/base_spec.rb
@@ -19,4 +19,20 @@ describe ReminderDecorator::Base do
       end
     end
   end
+
+  describe "#supervisor_slack_channel_display" do
+    context "supervisor_slack_channel present" do
+      it "return supervisor_slack_channel" do
+        reminder.supervisor_slack_channel = "channel"
+        expect(decorator.supervisor_slack_channel_display).to eq("channel")
+      end
+    end
+
+    context "supervisor_slack_channel not present" do
+      it "return placeholder string" do
+        reminder.supervisor_slack_channel = ""
+        expect(decorator.supervisor_slack_channel_display).to eq("Not specified.")
+      end
+    end
+  end
 end

--- a/spec/decorators/reminder_decorator/base_spec.rb
+++ b/spec/decorators/reminder_decorator/base_spec.rb
@@ -31,7 +31,8 @@ describe ReminderDecorator::Base do
     context "supervisor_slack_channel not present" do
       it "return placeholder string" do
         reminder.supervisor_slack_channel = ""
-        expect(decorator.supervisor_slack_channel_display).to eq("Not specified.")
+        expect(decorator.supervisor_slack_channel_display)
+          .to eq("Not specified.")
       end
     end
   end

--- a/spec/use_cases/check_assignments/assign_person_spec.rb
+++ b/spec/use_cases/check_assignments/assign_person_spec.rb
@@ -32,7 +32,7 @@ describe CheckAssignments::AssignPerson do
     u = user.name
     r = reminder.name
     p = project.name
-    "#{u} got assigned to do next #{r} in #{p}. "
+    "#{u} got assigned to do next #{r} in #{p}. They were notified by email."
   end
 
   before do

--- a/spec/use_cases/check_assignments/complete_spec.rb
+++ b/spec/use_cases/check_assignments/complete_spec.rb
@@ -74,13 +74,14 @@ describe CheckAssignments::Complete do
 
       it "notifies supervisor slack channel" do
         message = "Just letting you know that " \
-                  "John Doe has completed Awesome review in The Project."
+                  "John Doe has completed Awesome review in The Project: " \
+                  "http://example.com"
         expect_any_instance_of(Notifier).to receive(:notify_slack)
           .with(
             message,
             channel: '#supervisors',
           ).and_return({})
-        service.call
+        service.call(note_url: "http://example.com")
       end
     end
   end

--- a/spec/use_cases/check_assignments/complete_spec.rb
+++ b/spec/use_cases/check_assignments/complete_spec.rb
@@ -73,9 +73,11 @@ describe CheckAssignments::Complete do
       end
 
       it "notifier supervisor_slack_channel" do
+        message = "Just letting you know that " \
+                  "John Doe has completed Awesome review in The Project."
         expect_any_instance_of(Notifier).to receive(:notify_slack)
           .with(
-            "Just letting you know that John Doe has completed Awesome review in The Project.",
+            message,
             channel: '#supervisors',
           ).and_return({})
         service.call

--- a/spec/use_cases/check_assignments/complete_spec.rb
+++ b/spec/use_cases/check_assignments/complete_spec.rb
@@ -13,10 +13,18 @@ describe CheckAssignments::Complete do
   describe "#call" do
     let(:user) { create(:user) }
     let(:checker) { create(:user) }
-    let(:project_check) { create(:project_check) }
+    let(:project_check) { create(:project_check, reminder: reminder) }
+    let(:reminder) { create(:reminder) }
     let(:assignment) do
       create(:check_assignment, user: user,
                                 project_check: project_check)
+    end
+
+    around do |example|
+      previous = AppConfig["slack_enabled"]
+      AppConfig["slack_enabled"] = "true"
+      example.run
+      AppConfig["slack_enabled"] = previous
     end
 
     it "adds completion date to assignment" do
@@ -45,6 +53,23 @@ describe CheckAssignments::Complete do
       service.call
       expect(project_check.last_check_date).to eq assignment.completion_date
       expect(project_check.last_check_user).to eq checker
+    end
+
+    it "does not notify by slack" do
+      service.call
+      expect_any_instance_of(Notifier).not_to receive(:notify_slack)
+    end
+
+    context "supervisor_slack_channel is set on reminder" do
+      let(:project_check) { create(:project_check, project: project, reminder: reminder) }
+      let(:project) { create(:project, name: 'The Project') }
+      let(:reminder) { create(:reminder, supervisor_slack_channel: 'supervisors', name: 'Awesome review') }
+
+      it "notifier supervisor_slack_channel" do
+        expect_any_instance_of(Notifier)
+          .to receive(:notify_slack).with('Just letting you know that John Doe has completed Awesome review in The Project.', { channel: '#supervisors' }).and_return({})
+        service.call
+      end
     end
   end
 end

--- a/spec/use_cases/check_assignments/complete_spec.rb
+++ b/spec/use_cases/check_assignments/complete_spec.rb
@@ -55,7 +55,7 @@ describe CheckAssignments::Complete do
       expect(project_check.last_check_user).to eq checker
     end
 
-    it "does not notify by slack" do
+    it "does not notify slack" do
       service.call
       expect_any_instance_of(Notifier).not_to receive(:notify_slack)
     end
@@ -72,7 +72,7 @@ describe CheckAssignments::Complete do
               )
       end
 
-      it "notifier supervisor_slack_channel" do
+      it "notifies supervisor slack channel" do
         message = "Just letting you know that " \
                   "John Doe has completed Awesome review in The Project."
         expect_any_instance_of(Notifier).to receive(:notify_slack)

--- a/spec/use_cases/check_assignments/complete_spec.rb
+++ b/spec/use_cases/check_assignments/complete_spec.rb
@@ -61,13 +61,23 @@ describe CheckAssignments::Complete do
     end
 
     context "supervisor_slack_channel is set on reminder" do
-      let(:project_check) { create(:project_check, project: project, reminder: reminder) }
-      let(:project) { create(:project, name: 'The Project') }
-      let(:reminder) { create(:reminder, supervisor_slack_channel: 'supervisors', name: 'Awesome review') }
+      let(:project_check) do
+        create(:project_check, project: project, reminder: reminder)
+      end
+      let(:project) { create(:project, name: "The Project") }
+      let(:reminder) do
+        create(:reminder,
+               supervisor_slack_channel: "supervisors",
+               name: "Awesome review",
+              )
+      end
 
       it "notifier supervisor_slack_channel" do
-        expect_any_instance_of(Notifier)
-          .to receive(:notify_slack).with('Just letting you know that John Doe has completed Awesome review in The Project.', { channel: '#supervisors' }).and_return({})
+        expect_any_instance_of(Notifier).to receive(:notify_slack)
+          .with(
+            "Just letting you know that John Doe has completed Awesome review in The Project.",
+            channel: '#supervisors',
+          ).and_return({})
         service.call
       end
     end

--- a/spec/use_cases/check_assignments/create_completed_spec.rb
+++ b/spec/use_cases/check_assignments/create_completed_spec.rb
@@ -15,7 +15,7 @@ describe CheckAssignments::CreateCompleted do
 
   describe "#call" do
     let(:checker) { create(:user) }
-    let(:project_check) { create(:project_check) }
+    let(:project_check) { create(:project_check, reminder: create(:reminder)) }
 
     it "creates new assignment with completion date" do
       expect(repo.latest_assignment(project_check))


### PR DESCRIPTION
Added new optional attribute to Reminder: `supervisor_slack_channel`

When a CheckAssignment is completed, supervisor channel is notified like this:

`Just letting you know that John Smith has completed Leaders review in Reminders: http://example.com/review-note-url`