### PR TITLE
aligned comment icon to be in one line

### DIFF
--- a/app/assets/stylesheets/views/project_checks.scss
+++ b/app/assets/stylesheets/views/project_checks.scss
@@ -1,3 +1,7 @@
 .days-left {
   min-width: 54px;
 }
+
+.project_check-info {
+  min-width: 98px;
+}

--- a/app/views/project_checks/index.slim
+++ b/app/views/project_checks/index.slim
@@ -15,7 +15,7 @@
           th Project
           th Last check
           th Days left
-          th Info
+          th Comment
           th Last checked by
           th History
           th Check now?
@@ -44,7 +44,7 @@
                           i.glyphicon.glyphicon-pushpin
               - else
                 = pc.days_to_deadline
-            td
+            td.project_check-info
               - if pc.info.present?
                 i.glyphicon.glyphicon-comment.info-tooltip data-placement="top" data-toggle="tooltip" title=pc.info
               = link_to "Edit", edit_project_check_path(pc), class: "btn btn-info"


### PR DESCRIPTION
Aligned icon and changed `info` to `comment`

Task: https://trello.com/c/UCLrtXBm/47-apka-reminders-pokazywanie-komentarzy-w-widoku-listy-projektow