### PR TITLE
Slack notifications prior to expiration

### DIFF
--- a/app/use_cases/project_checks/handle_notification_day.rb
+++ b/app/use_cases/project_checks/handle_notification_day.rb
@@ -3,5 +3,16 @@ module ProjectChecks
     def notification_template
       reminder.notification_text
     end
+
+    def notify!
+      project_channel.present? && ['members'].each do |member|
+        notifier
+          .send_message notification, channel: member
+      end
+    end
+
+    def project_channel
+      notifier.client.channels_list['channels'].detect { |channel| channel['name'] == check.project.channel_name }
+    end
   end
 end

--- a/app/use_cases/project_checks/handle_notification_day.rb
+++ b/app/use_cases/project_checks/handle_notification_day.rb
@@ -5,7 +5,14 @@ module ProjectChecks
     end
 
     def notify!
-      project_channel.present? && ['members'].each do |member|
+      notifier
+        .send_message notification, channel: "##{check.decorate.slack_channel}"
+
+      notify_team_members!
+    end
+
+    def notify_team_members!
+      project_channel.present? && project_channel['members'].each do |member|
         notifier
           .send_message notification, channel: member
       end

--- a/app/use_cases/project_checks/handle_notification_day.rb
+++ b/app/use_cases/project_checks/handle_notification_day.rb
@@ -7,7 +7,6 @@ module ProjectChecks
     def notify!
       notifier
         .send_message notification, channel: "##{check.decorate.slack_channel}"
-
       notify_team_members!
     end
 

--- a/app/use_cases/project_checks/handle_overdue.rb
+++ b/app/use_cases/project_checks/handle_overdue.rb
@@ -17,7 +17,6 @@ module ProjectChecks
     private
 
     def mail!
-      # return unless email_enabled?
       mailer.check_reminder(notification, check).deliver_now
     end
 

--- a/app/use_cases/project_checks/handle_overdue.rb
+++ b/app/use_cases/project_checks/handle_overdue.rb
@@ -17,7 +17,7 @@ module ProjectChecks
     private
 
     def mail!
-      return unless email_enabled?
+      # return unless email_enabled?
       mailer.check_reminder(notification, check).deliver_now
     end
 

--- a/spec/use_cases/project_checks/handle_notification_day_spec.rb
+++ b/spec/use_cases/project_checks/handle_notification_day_spec.rb
@@ -21,6 +21,7 @@ describe ProjectChecks::HandleNotificationDay do
       .to receive(:email) { "foo-project@foo.com" }
     allow(check).to receive(:decorate) { check }
     allow(check).to receive(:slack_channel) { "foo-project" }
+    allow_any_instance_of(ProjectChecks::HandleNotificationDay).to receive(:project_channel) { { 'members' => [] } }
   end
 
   describe "#call" do


### PR DESCRIPTION
## Description
- Send slack notifications to each member of project team when review time approaches
- Send email to project email when review time approaches