### PR TITLE
don't report 404 errors to rollbar

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -2,6 +2,6 @@ require "rollbar/rails"
 
 Rollbar.configure do |config|
   config.access_token = AppConfig.rollbar_token
-  config.exception_level_filters['ActionController::RoutingError'] = 'ignore'
+  config.exception_level_filters["ActionController::RoutingError"] = "ignore"
   config.enabled = false if Rails.env.test? || Rails.env.development?
 end

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -2,5 +2,12 @@ require "rollbar/rails"
 
 Rollbar.configure do |config|
   config.access_token = AppConfig.rollbar_token
+  
+  config.exception_level_filters.merge!({
+    'ActionController::RoutingError' => lambda do |error|
+      error.message.include?('apple-touch-icon') ? 'ignore' : 'error'
+    end
+  })
+  
   config.enabled = false if Rails.env.test? || Rails.env.development?
 end

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -2,12 +2,6 @@ require "rollbar/rails"
 
 Rollbar.configure do |config|
   config.access_token = AppConfig.rollbar_token
-  
-  config.exception_level_filters.merge!({
-    'ActionController::RoutingError' => lambda do |error|
-      error.message.include?('apple-touch-icon') ? 'ignore' : 'error'
-    end
-  })
-  
+  config.exception_level_filters['ActionController::RoutingError'] = 'ignore'
   config.enabled = false if Rails.env.test? || Rails.env.development?
 end


### PR DESCRIPTION
Implemented to solve [this problem](https://netguru.atlassian.net/browse/SUP-1542). Those errors needlessly eat our quota, so they should be ignored.