### PR TITLE
RDN/RD-52 new matrix input

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ gem "rails", "~> 5"
 
 gem "app_konfig"
 gem "bootstrap-datepicker-rails"
+gem 'bootstrap-toggle-rails'
 gem "coffee-rails"
 gem "data_guru"
 gem "decent_exposure"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,7 @@ GEM
     bootstrap-sass (3.3.6)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
+    bootstrap-toggle-rails (2.2.1.0)
     bourbon (3.2.4)
       sass (~> 3.2)
       thor
@@ -421,6 +422,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootstrap-datepicker-rails
+  bootstrap-toggle-rails
   byebug
   capistrano
   capistrano-docker!
@@ -475,4 +477,4 @@ DEPENDENCIES
   zonebie
 
 BUNDLED WITH
-   1.11.2
+   1.13.7

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,4 +17,5 @@
 //= require bootstrap-datepicker
 //= require turbolinks
 //= require netguru_theme
+//= require bootstrap-toggle
 //= require_tree .

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,6 @@
 // *= require_self
 // *= require dataTables/bootstrap/2/jquery.dataTables.bootstrap
+// *= require bootstrap-toggle
 
 @import "bootstrap-sprockets";
 @import "bootstrap-datepicker3";

--- a/app/views/project_reminders_matrix/index.slim
+++ b/app/views/project_reminders_matrix/index.slim
@@ -20,13 +20,11 @@
               - pc = ProjectCheckDecorator.new(project_checks_repo.find_by_reminder_and_project(reminder, project))
               td
                 - if pc.enabled?
-                  = button_to project_check_toggle_state_path(pc), method: :post, class: 'btn btn-danger btn-primary btn-xs' do
-                    i class='glyphicon glyphicon-remove'
-                    |  Disable
+                  = link_to project_check_toggle_state_path(pc), method: :post do
+                    input checked="" data-toggle="toggle" type="checkbox" data-on="Enabled" data-off="Disabled"
                 - elsif pc.present?
-                  = button_to project_check_toggle_state_path(pc), method: :post, class: 'btn btn-success btn-xs' do
-                    i class='glyphicon glyphicon-ok'
-                    |  Enable
+                  = link_to project_check_toggle_state_path(pc), method: :post do
+                    input type="checkbox" data-toggle="toggle" data-on="Enabled" data-off="Disabled"
                 - else
                   = button_to reminder_path(reminder), method: :get, class: 'btn btn-warning btn-xs' do
                     i class='glyphicon glyphicon-refresh'


### PR DESCRIPTION
#RD-52 add much more readable input under `/project_reminders_matrix` path. The input enable and disable reviews scope per project.