### PR TITLE
Fix project checks ignoring disabled period when calculating due dates

### DIFF
--- a/app/controllers/project_checks_controller.rb
+++ b/app/controllers/project_checks_controller.rb
@@ -45,9 +45,8 @@ class ProjectChecksController < ApplicationController
 
   # rubocop:disable Metrics/AbcSize
   def toggle_state
-    check.enabled = !check.enabled
     redirect_path = request.referrer || reminder_path(check.reminder)
-    if check.save
+    if project_checks_repository.update(check, enabled: !check.enabled)
       redirect_to redirect_path, notice: "All right!"
     else
       redirect_to redirect_path,

--- a/app/repositories/project_checks_repository.rb
+++ b/app/repositories/project_checks_repository.rb
@@ -49,7 +49,7 @@ class ProjectChecksRepository
       params.merge(
         disabled_date: nil,
         last_check_date_without_disabled_period: date_without_disabled(check),
-        created_at: created_at_moved_forward(check)
+        created_at: created_at_moved_forward(check),
       )
     else
       params.merge(disabled_date: Time.zone.today)

--- a/app/repositories/project_checks_repository.rb
+++ b/app/repositories/project_checks_repository.rb
@@ -49,9 +49,10 @@ class ProjectChecksRepository
       params.merge(
         disabled_date: nil,
         last_check_date_without_disabled_period: date_without_disabled(check),
+        created_at: created_at_moved_forward(check)
       )
     else
-      params.merge(disabled_date: Date.today)
+      params.merge(disabled_date: Time.zone.today)
     end
   end
 
@@ -60,10 +61,18 @@ class ProjectChecksRepository
     without_disabled = check.last_check_date_without_disabled_period
     latest_data = [check.last_check_date, without_disabled].compact.max
 
-    latest_data + (Date.today - check.disabled_date)
+    latest_data + (Time.zone.today - check.disabled_date)
   end
 
   def ids_for_project(project)
     project.project_checks.ids
+  end
+
+  private
+
+  def created_at_moved_forward(check)
+    return check.created_at if check.last_check_date
+    days_diff = Time.zone.today - check.disabled_date
+    check.created_at + days_diff.days
   end
 end

--- a/app/repositories/project_checks_repository.rb
+++ b/app/repositories/project_checks_repository.rb
@@ -71,7 +71,7 @@ class ProjectChecksRepository
   private
 
   def created_at_moved_forward(check)
-    return check.created_at if check.last_check_date
+    return check.created_at if check.last_check_date || check.disabled_date.nil?
     days_diff = Time.zone.today - check.disabled_date
     check.created_at + days_diff.days
   end

--- a/db/migrate/20170321153119_update_missing_disabled_date_for_disabled_project_checks.rb
+++ b/db/migrate/20170321153119_update_missing_disabled_date_for_disabled_project_checks.rb
@@ -1,0 +1,7 @@
+class UpdateMissingDisabledDateForDisabledProjectChecks < ActiveRecord::Migration[5.0]
+  def up
+    ProjectCheck.where(enabled: false, disabled_date: nil).each do |pc|
+      pc.update(disabled_date: pc.updated_at)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170310102524) do
+ActiveRecord::Schema.define(version: 20170321153119) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/controllers/project_checks_controller_spec.rb
+++ b/spec/controllers/project_checks_controller_spec.rb
@@ -64,6 +64,14 @@ describe ProjectChecksController do
           .from(true).to(false)
       end
 
+      it "uses a repository to update the record" do
+        repo = ProjectChecksRepository.new()
+        expect(ProjectChecksRepository).to receive(:new).and_return(repo)
+        expect(repo).to receive(:update).with(project_check,
+                                              enabled: !project_check.enabled)
+        subject
+      end
+
       it "renders a notice" do
         subject
         expect(flash[:notice]).to have_text("All right!")

--- a/spec/controllers/project_checks_controller_spec.rb
+++ b/spec/controllers/project_checks_controller_spec.rb
@@ -65,7 +65,7 @@ describe ProjectChecksController do
       end
 
       it "uses a repository to update the record" do
-        repo = ProjectChecksRepository.new()
+        repo = ProjectChecksRepository.new
         expect(ProjectChecksRepository).to receive(:new).and_return(repo)
         expect(repo).to receive(:update).with(project_check,
                                               enabled: !project_check.enabled)

--- a/spec/migrations/update_missing_disabled_date_for_disabled_project_checks_spec.rb
+++ b/spec/migrations/update_missing_disabled_date_for_disabled_project_checks_spec.rb
@@ -13,14 +13,14 @@ describe UpdateMissingDisabledDateForDisabledProjectChecks do
   describe "#up" do
     context "when project check is enabled" do
       it "doesn't change anything" do
-        expect{ migration.up }.not_to change { ProjectCheck.all }
+        expect { migration.up }.not_to change { ProjectCheck.all }
       end
     end
 
     context "when project check is disabled" do
       context "and has no disabled_date" do
         it "sets disabled_date to updated_at" do
-          expect{ migration.up }
+          expect { migration.up }
             .to change { disabled_nil.reload.disabled_date }
             .to disabled_nil.updated_at.to_date
         end
@@ -28,7 +28,7 @@ describe UpdateMissingDisabledDateForDisabledProjectChecks do
 
       context "and has a disabled_date" do
         it "doesn't change anything" do
-          expect{ migration.up }.not_to change { ProjectCheck.all }
+          expect { migration.up }.not_to change { ProjectCheck.all }
         end
       end
     end

--- a/spec/migrations/update_missing_disabled_date_for_disabled_project_checks_spec.rb
+++ b/spec/migrations/update_missing_disabled_date_for_disabled_project_checks_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+require File.join(Rails.root,
+                  "db",
+                  "migrate",
+                  "20170321153119_update_missing_disabled_date_for_disabled_project_checks.rb")
+
+describe UpdateMissingDisabledDateForDisabledProjectChecks do
+  let(:migration) { described_class.new }
+  let(:enabled) { create(:project_check, enabled: true) }
+  let(:disabled) { create(:project_check, enabled: false, disabled_date: 1.month.ago) }
+  let(:disabled_nil) { create(:project_check, enabled: false, disabled_date: nil) }
+
+  describe "#up" do
+    context "when project check is enabled" do
+      it "doesn't change anything" do
+        expect{ migration.up }.not_to change { ProjectCheck.all }
+      end
+    end
+
+    context "when project check is disabled" do
+      context "and has no disabled_date" do
+        it "sets disabled_date to updated_at" do
+          expect{ migration.up }
+            .to change { disabled_nil.reload.disabled_date }
+            .to disabled_nil.updated_at.to_date
+        end
+      end
+
+      context "and has a disabled_date" do
+        it "doesn't change anything" do
+          expect{ migration.up }.not_to change { ProjectCheck.all }
+        end
+      end
+    end
+  end
+end

--- a/spec/models/project_check_spec.rb
+++ b/spec/models/project_check_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+describe ProjectCheck do
+  it { is_expected.to belong_to :project }
+  it { is_expected.to belong_to :reminder }
+  it { is_expected.to belong_to(:last_check_user).class_name("User") }
+  it { is_expected.to have_many(:check_assignments)
+                      .order(created_at: :desc)
+                      .dependent(:destroy) }
+
+  it "validates that project is enabled before enabling self" do
+    project_check = create(:project_check,
+                           enabled: false,
+                           project: create(:project, enabled: false))
+    project_check.update(enabled: true)
+    expect(project_check).not_to be_valid
+  end
+end

--- a/spec/models/project_check_spec.rb
+++ b/spec/models/project_check_spec.rb
@@ -4,9 +4,11 @@ describe ProjectCheck do
   it { is_expected.to belong_to :project }
   it { is_expected.to belong_to :reminder }
   it { is_expected.to belong_to(:last_check_user).class_name("User") }
-  it { is_expected.to have_many(:check_assignments)
-                      .order(created_at: :desc)
-                      .dependent(:destroy) }
+  it do
+    is_expected.to have_many(:check_assignments)
+      .order(created_at: :desc)
+      .dependent(:destroy)
+  end
 
   it "validates that project is enabled before enabling self" do
     project_check = create(:project_check,

--- a/spec/repositories/project_checks_repository_spec.rb
+++ b/spec/repositories/project_checks_repository_spec.rb
@@ -100,7 +100,7 @@ describe ProjectChecksRepository do
 
       context "that was checked before" do
         let(:attrs) do
-          { disabled_date: 2.week.ago,
+          { disabled_date: 2.weeks.ago,
             enabled: false,
             last_check_date: 3.weeks.ago }
         end


### PR DESCRIPTION
## Ticket
https://netguru.atlassian.net/browse/RD-94

## Description
- Make sure all disabled checks have a `disabled_date` set (data migration and controller)
- The disabled period is included in calculations by using the `last_check_date_without_disabled_period` column, but it's only set if there was a `last_check_date`. So if a recently enabled check didn't have a `last_check_date`, the disabled period was ignored. To solve this we update its `created_at` column to reflect the disabled period (that's also how overriding a deadline works).
- Add more specs and refactor old ones