### PR TITLE
Stop changing created_at

### DIFF
--- a/app/decorators/project_check_decorator.rb
+++ b/app/decorators/project_check_decorator.rb
@@ -46,10 +46,10 @@ class ProjectCheckDecorator < BaseDecorator
   end
 
   def days_to_deadline_as_number
-    to_date = object.last_check_date || object.created_at.to_date
-    to_date += object.reminder.valid_for_n_days.days
-    from_date = Time.zone.today
-    (to_date - from_date).to_i
+    policy = DueDatePolicy.new(object,
+                               valid_for_n_days: object.reminder.valid_for_n_days,
+                               remind_after_days: object.reminder.remind_after_days)
+    policy.due_in
   end
 
   def days_to_deadline

--- a/app/jobs/project_checked_on_time_job.rb
+++ b/app/jobs/project_checked_on_time_job.rb
@@ -6,11 +6,10 @@ class ProjectCheckedOnTimeJob
     @project_check_id = project_check_id
   end
 
-  # rubocop:disable Metrics/AbcSize
   def perform
-    if handler = select_handler
-      handler.new(project_check, policy.elapsed_days).call
-    end
+    handler = select_handler
+    return if handler.nil?
+    handler.new(project_check, policy.elapsed_days).call
   end
 
   private

--- a/app/models/project_check.rb
+++ b/app/models/project_check.rb
@@ -11,14 +11,6 @@ class ProjectCheck < ActiveRecord::Base
   scope :enabled, -> { where(enabled: true) }
   scope :without_jira_issue, -> { where(jira_issue_key: nil) }
 
-  def deadline
-    if checked?
-      real_last_check_date + reminder.valid_for_n_days.to_i
-    else
-      created_at.to_date + reminder.init_valid_for_n_days.to_i
-    end
-  end
-
   def checked?
     last_check_date.present?
   end

--- a/app/policies/due_date_policy.rb
+++ b/app/policies/due_date_policy.rb
@@ -1,0 +1,42 @@
+class DueDatePolicy
+  attr_reader :project_check
+
+  delegate :reminder, to: :project_check
+
+  def initialize(project_check)
+    @project_check = project_check
+  end
+
+  def due_on
+    date_to_count_from + reminder.valid_for_n_days
+  end
+
+  def due_in
+    due_on - Time.zone.today
+  end
+
+  def overdue?
+    due_in < 0
+  end
+
+  def remind_on
+    reminder.remind_after_days.map do |days|
+      date_to_count_from + days.to_i
+    end.sort
+  end
+
+  private
+
+  def date_to_count_from
+    if checked_before?
+      [project_check.last_check_date,
+       project_check.last_check_date_without_disabled_period].compact.max
+    else
+      project_check.created_at
+    end.to_date
+  end
+
+  def checked_before?
+    project_check.last_check_date.present?
+  end
+end

--- a/app/policies/due_date_policy.rb
+++ b/app/policies/due_date_policy.rb
@@ -12,7 +12,7 @@ class DueDatePolicy
   end
 
   def due_in
-    due_on - Time.zone.today
+    (due_on - Time.zone.today).to_i
   end
 
   def overdue?

--- a/app/policies/due_date_policy.rb
+++ b/app/policies/due_date_policy.rb
@@ -44,8 +44,7 @@ class DueDatePolicy
       [project_check.last_check_date,
        project_check.last_check_date_without_disabled_period].compact.max
     else
-      [project_check.created_at,
-       project_check.created_at_without_disabled_period].compact.max
+      project_check.created_at_without_disabled_period || project_check.created_at
     end.to_date
   end
 

--- a/app/policies/due_date_policy.rb
+++ b/app/policies/due_date_policy.rb
@@ -44,7 +44,8 @@ class DueDatePolicy
       [project_check.last_check_date,
        project_check.last_check_date_without_disabled_period].compact.max
     else
-      project_check.created_at
+      [project_check.created_at,
+       project_check.created_at_without_disabled_period].compact.max
     end.to_date
   end
 

--- a/app/policies/due_date_policy.rb
+++ b/app/policies/due_date_policy.rb
@@ -6,26 +6,12 @@ class DueDatePolicy
     @reminder = project_check.reminder
   end
 
-  def due_on
-    date_to_count_from + valid_for_n_days
-  end
-
   def due_in
     (due_on - Time.zone.today).to_i
   end
 
   def overdue?
     due_in < 0
-  end
-
-  def remind_on
-    remind_after_days.map do |days|
-      date_to_count_from + days.to_i
-    end.sort
-  end
-
-  def remind_on?(date)
-    remind_on.include?(date.to_date)
   end
 
   def remind_today?
@@ -37,6 +23,20 @@ class DueDatePolicy
   end
 
   private
+
+  def due_on
+    date_to_count_from + valid_for_n_days
+  end
+
+  def remind_on
+    remind_after_days.map do |days|
+      date_to_count_from + days.to_i
+    end.sort
+  end
+
+  def remind_on?(date)
+    remind_on.include?(date.to_date)
+  end
 
   def date_to_count_from
     if checked_before?

--- a/app/policies/due_date_policy.rb
+++ b/app/policies/due_date_policy.rb
@@ -1,14 +1,14 @@
 class DueDatePolicy
-  attr_reader :project_check
+  attr_reader :project_check, :valid_for_n_days, :remind_after_days
 
-  delegate :reminder, to: :project_check
-
-  def initialize(project_check)
+  def initialize(project_check, valid_for_n_days, remind_after_days)
     @project_check = project_check
+    @valid_for_n_days = valid_for_n_days
+    @remind_after_days = remind_after_days
   end
 
   def due_on
-    date_to_count_from + reminder.valid_for_n_days
+    date_to_count_from + valid_for_n_days
   end
 
   def due_in
@@ -20,7 +20,7 @@ class DueDatePolicy
   end
 
   def remind_on
-    reminder.remind_after_days.map do |days|
+    remind_after_days.map do |days|
       date_to_count_from + days.to_i
     end.sort
   end

--- a/app/policies/due_date_policy.rb
+++ b/app/policies/due_date_policy.rb
@@ -1,7 +1,7 @@
 class DueDatePolicy
   attr_reader :project_check, :valid_for_n_days, :remind_after_days
 
-  def initialize(project_check, valid_for_n_days, remind_after_days)
+  def initialize(project_check, valid_for_n_days:, remind_after_days:)
     @project_check = project_check
     @valid_for_n_days = valid_for_n_days
     @remind_after_days = remind_after_days
@@ -23,6 +23,18 @@ class DueDatePolicy
     remind_after_days.map do |days|
       date_to_count_from + days.to_i
     end.sort
+  end
+
+  def remind_on?(date)
+    remind_on.include?(date.to_date)
+  end
+
+  def remind_today?
+    remind_on?(Time.zone.today)
+  end
+
+  def elapsed_days
+    (Time.zone.today - date_to_count_from).to_i
   end
 
   private

--- a/app/repositories/project_checks_repository.rb
+++ b/app/repositories/project_checks_repository.rb
@@ -49,7 +49,7 @@ class ProjectChecksRepository
       params.merge(
         disabled_date: nil,
         last_check_date_without_disabled_period: date_without_disabled(check),
-        created_at: created_at_moved_forward(check),
+        created_at_without_disabled_period: created_at_without_disabled(check),
       )
     else
       params.merge(disabled_date: Time.zone.today)
@@ -70,9 +70,13 @@ class ProjectChecksRepository
 
   private
 
-  def created_at_moved_forward(check)
-    return check.created_at if check.last_check_date || check.disabled_date.nil?
+  def created_at_without_disabled(check)
+    return check.created_at_without_disabled_period if check.last_check_date ||
+                                                       check.disabled_date.nil?
+    latest_datetime = [check.created_at_without_disabled_period,
+                       check.created_at].compact.max
     days_diff = Time.zone.today - check.disabled_date
-    check.created_at + days_diff.days
+
+    latest_datetime + days_diff.days
   end
 end

--- a/app/repositories/project_checks_repository.rb
+++ b/app/repositories/project_checks_repository.rb
@@ -71,12 +71,11 @@ class ProjectChecksRepository
   private
 
   def created_at_without_disabled(check)
-    return check.created_at_without_disabled_period if check.last_check_date ||
-                                                       check.disabled_date.nil?
-    latest_datetime = [check.created_at_without_disabled_period,
-                       check.created_at].compact.max
+    return nil if check.last_check_date
+    return check.created_at_without_disabled if check.disabled_date.nil?
+    base_datetime = check.created_at_without_disabled_period || check.created_at
     days_diff = Time.zone.today - check.disabled_date
 
-    latest_datetime + days_diff.days
+    base_datetime + days_diff.days
   end
 end

--- a/app/use_cases/project_checks/override_deadline.rb
+++ b/app/use_cases/project_checks/override_deadline.rb
@@ -12,7 +12,7 @@ module ProjectChecks
     def call
       return false unless allow_override?
       attrs = {
-        created_at: calc_new_created_at,
+        created_at_without_disabled_period: calc_new_created_at,
       }
       checks_repo.update(check, attrs)
     end

--- a/db/migrate/20170329095336_add_started_at_to_project_checks.rb
+++ b/db/migrate/20170329095336_add_started_at_to_project_checks.rb
@@ -1,0 +1,5 @@
+class AddStartedAtToProjectChecks < ActiveRecord::Migration[5.0]
+  def change
+    add_column :project_checks, :created_at_without_disabled_period, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170324135327) do
+ActiveRecord::Schema.define(version: 20170329095336) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -52,6 +52,7 @@ ActiveRecord::Schema.define(version: 20170324135327) do
     t.date     "disabled_date"
     t.datetime "jira_issue_created_at"
     t.string   "jira_issue_key"
+    t.datetime "created_at_without_disabled_period"
     t.index ["project_id"], name: "index_project_checks_on_project_id", using: :btree
     t.index ["reminder_id"], name: "index_project_checks_on_reminder_id", using: :btree
   end

--- a/spec/decorators/project_check_decorator_spec.rb
+++ b/spec/decorators/project_check_decorator_spec.rb
@@ -134,9 +134,9 @@ describe ProjectCheckDecorator do
     it "includes disabled period in the calculations" do
       reminder = create(:reminder, valid_for_n_days: 30)
       check = create(:project_check,
-             reminder: reminder,
-             last_check_date: 20.days.ago,
-             last_check_date_without_disabled_period: 10.days.ago)
+                     reminder: reminder,
+                     last_check_date: 20.days.ago,
+                     last_check_date_without_disabled_period: 10.days.ago)
       decorator = described_class.new(check)
       expect(decorator.days_to_deadline_as_number).to eq 20
     end

--- a/spec/decorators/project_check_decorator_spec.rb
+++ b/spec/decorators/project_check_decorator_spec.rb
@@ -129,4 +129,16 @@ describe ProjectCheckDecorator do
       it { is_expected.to eq "disabled" }
     end
   end
+
+  describe "#days_to_deadline_as_number" do
+    it "includes disabled period in the calculations" do
+      reminder = create(:reminder, valid_for_n_days: 30)
+      check = create(:project_check,
+             reminder: reminder,
+             last_check_date: 20.days.ago,
+             last_check_date_without_disabled_period: 10.days.ago)
+      decorator = described_class.new(check)
+      expect(decorator.days_to_deadline_as_number).to eq 20
+    end
+  end
 end

--- a/spec/features/due_dates_spec.rb
+++ b/spec/features/due_dates_spec.rb
@@ -1,0 +1,104 @@
+require "rails_helper"
+
+feature "Due dates of project checks" do
+  let(:user) { create(:admin) }
+  let(:reminder_page) { Reminders::ReminderPage.new }
+  let(:reminder) do
+    create :reminder,
+           valid_for_n_days: 30,
+           remind_after_days: [],
+           deadline_text: "Days ago: {{days_ago}}",
+           notification_text: "Days ago: {{days_ago}}"
+  end
+  let(:project)  { create :project }
+  let!(:project_check) do
+    create :project_check, reminder: reminder, project: project
+  end
+  let(:days_to_deadline) do
+    reminder_page.project_rows.first.days_to_deadline
+  end
+
+  before do
+    log_in(user)
+  end
+
+  scenario "A project/reminder combo that was never checked" do
+    Timecop.travel(10.days.from_now)
+    reminder_page.load reminder_id: reminder.id
+    CheckReminderJob.new.perform reminder.id
+
+    days = days_to_deadline.find('input#project_check_days_left').value
+    expect(days).to eq "20"
+    expect(ActionMailer::Base.deliveries).to be_empty
+  end
+
+  scenario "A project/reminder combo that was checked before" do
+    Timecop.travel(5.days.from_now)
+    reminder_page.load reminder_id: reminder.id
+    reminder_page.project_rows.first.mark_as_checked!
+
+    Timecop.travel(20.days.from_now)
+    reminder_page.load reminder_id: reminder.id
+    deadline = reminder_page.project_rows.first.days_to_deadline.text
+
+    expect(deadline).to eq "10"
+  end
+
+  scenario "An unchecked project/reminder combo that would be overdue if it wasn't disabled", js: true do
+    Timecop.travel(5.days.from_now)
+    reminder_page.load reminder_id: reminder.id
+    wait_for_jquery
+    reminder_page.project_rows.first.toggle_state!
+
+    Timecop.travel(20.days.from_now)
+    reminder_page.within('.project-checks-filters') { click_link "Disabled" }
+    reminder_page.project_rows.first.toggle_state!
+
+    Timecop.travel(3.days.from_now)
+    reminder_page.load reminder_id: reminder.id
+
+    days = reminder_page.project_rows.first.deadline_input.value
+    expect(days).to eq "22"
+  end
+
+  scenario "A project/reminder combo that would be overdue if it wasn't disabled", js: true do
+    Timecop.travel(5.days.from_now)
+    reminder_page.load reminder_id: reminder.id
+    wait_for_jquery
+    reminder_page.project_rows.first.mark_as_checked!
+    reminder_page.project_rows.first.toggle_state!
+
+    Timecop.travel(20.days.from_now)
+    reminder_page.within('.project-checks-filters') { click_link "Disabled" }
+    reminder_page.project_rows.first.toggle_state!
+
+    Timecop.travel(3.days.from_now)
+    reminder_page.load reminder_id: reminder.id
+
+    days = reminder_page.project_rows.first.days_to_deadline.text
+    expect(days).to eq "27"
+  end
+
+  scenario "An overdue check including a disabled period", js: true do
+    Timecop.travel(20.days.from_now)
+    reminder_page.load reminder_id: reminder.id
+    wait_for_jquery
+    #reminder_page.project_rows.first.mark_as_checked!
+    reminder_page.project_rows.first.toggle_state!
+
+    Timecop.travel(10.days.from_now)
+    reminder_page.within('.project-checks-filters') { click_link "Disabled" }
+    reminder_page.project_rows.first.toggle_state!
+
+    Timecop.travel(20.days.from_now)
+    reminder_page.load reminder_id: reminder.id
+    CheckReminderJob.new.perform reminder.id
+    emails = ActionMailer::Base.deliveries
+
+    #days = reminder_page.project_rows.first.days_to_deadline.text
+    days = reminder_page.project_rows.first.deadline_input[:placeholder]
+    expect(days).to eq "after deadline"
+    expect(emails.count).to eq 1
+    expect(emails.first.body.raw_source).to include "Days ago: 40"
+  end
+end

--- a/spec/features/due_dates_spec.rb
+++ b/spec/features/due_dates_spec.rb
@@ -14,9 +14,6 @@ feature "Due dates of project checks" do
   let!(:project_check) do
     create :project_check, reminder: reminder, project: project
   end
-  let(:days_to_deadline) do
-    reminder_page.project_rows.first.days_to_deadline
-  end
 
   before do
     log_in(user)
@@ -37,14 +34,14 @@ feature "Due dates of project checks" do
   end
 
   context "A project_check that was never checked" do
+    let(:days) { reminder_page.project_rows.first.deadline.input }
+
     scenario "and isn't overdue" do
       Timecop.travel(10.days.from_now)
-      reminder_page.load reminder_id: reminder.id
       CheckReminderJob.new.perform reminder.id
       reload!
 
-      days = days_to_deadline.find("input#project_check_days_left").value
-      expect(days).to eq "20"
+      expect(days.value).to eq "20"
       expect(ActionMailer::Base.deliveries).to be_empty
     end
 
@@ -54,8 +51,7 @@ feature "Due dates of project checks" do
       Timecop.travel(3.days.from_now)
       reload!
 
-      days = reminder_page.project_rows.first.deadline_input.value
-      expect(days).to eq "22"
+      expect(days.value).to eq "22"
     end
 
     scenario "and is overdue despite being disabled for a period of time", js: true do
@@ -65,8 +61,7 @@ feature "Due dates of project checks" do
       CheckReminderJob.new.perform reminder.id
       reload!
 
-      days = reminder_page.project_rows.first.deadline_input[:placeholder]
-      expect(days).to eq "after deadline"
+      expect(days[:placeholder]).to eq "after deadline"
       emails = ActionMailer::Base.deliveries
       expect(emails.count).to eq 1
       expect(emails.first.body.raw_source).to include "Days ago: 40"
@@ -74,6 +69,8 @@ feature "Due dates of project checks" do
   end
 
   context "A project_check that was checked before" do
+    let(:days) { reminder_page.project_rows.first.deadline.text }
+
     before do
       Timecop.travel(5.days.from_now)
       reminder_page.project_rows.first.mark_as_checked!
@@ -83,8 +80,7 @@ feature "Due dates of project checks" do
       Timecop.travel(20.days.from_now)
       reload!
 
-      deadline = reminder_page.project_rows.first.days_to_deadline.text
-      expect(deadline).to eq "10"
+      expect(days).to eq "10"
     end
 
     scenario "and would be overdue if it wasn't disabled", js: true do
@@ -92,7 +88,6 @@ feature "Due dates of project checks" do
       Timecop.travel(3.days.from_now)
       reload!
 
-      days = reminder_page.project_rows.first.days_to_deadline.text
       expect(days).to eq "27"
     end
 
@@ -103,7 +98,6 @@ feature "Due dates of project checks" do
       CheckReminderJob.new.perform reminder.id
       reload!
 
-      days = reminder_page.project_rows.first.days_to_deadline.text
       expect(days).to eq "after deadline"
       emails = ActionMailer::Base.deliveries
       expect(emails.count).to eq 1

--- a/spec/jobs/project_checked_on_time_job_spec.rb
+++ b/spec/jobs/project_checked_on_time_job_spec.rb
@@ -16,6 +16,7 @@ describe ProjectCheckedOnTimeJob do
     let(:check) do
       double(:project_check, id: 1, last_check_date: last_check_date,
                              created_at: creation_time,
+                             created_at_without_disabled_period: nil,
                              last_check_date_without_disabled_period: nil)
     end
 

--- a/spec/jobs/project_checked_on_time_job_spec.rb
+++ b/spec/jobs/project_checked_on_time_job_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require "rails_helper"
 
 describe ProjectCheckedOnTimeJob do
   let(:job) { described_class.new(check.id, days_valid, daily_reminders) }

--- a/spec/policies/due_date_policy_spec.rb
+++ b/spec/policies/due_date_policy_spec.rb
@@ -16,33 +16,59 @@ describe DueDatePolicy do
   let(:init_valid_for_n_days) { 10 }
   let(:init_remind_after_days) { [5, 8] }
 
-  def create_check(attrs = {})
-    create(:project_check, attrs.merge(reminder: reminder))
+  shared_context "check disabled for duration" do |duration|
+    before do
+      repo = ProjectChecksRepository.new
+      repo.update(check, enabled: false)
+      check.update disabled_date: duration.ago
+      repo.update(check, enabled: true)
+      check
+    end
   end
 
-  def disable_check_for(duration)
-    repo = ProjectChecksRepository.new
-    repo.update(check, enabled: false)
-    check.update disabled_date: duration.ago
-    repo.update(check, enabled: true)
-    check
+  shared_examples "due date is in the past/the future/today" do |date_diff, stuff|
+    before do
+      allow(policy).to receive(:due_on).and_return(due_on_date)
+    end
+
+    context "when due date is in the future" do
+      let(:due_on_date) { date_diff.from_now.to_date }
+
+      it "returns the difference between today and due date in days" do
+        is_expected.to eq stuff[:future]
+      end
+    end
+
+    context "when due date is in the past" do
+      let(:due_on_date) { date_diff.ago.to_date }
+
+      it "returns the negative difference between today and due date in days" do
+        is_expected.to eq stuff[:past]
+      end
+    end
+
+    context "when due date is today" do
+      let(:due_on_date) { Time.zone.today.to_date }
+
+      it { is_expected.to eq stuff[:today] }
+    end
   end
 
   it { is_expected.to respond_to(:project_check) }
 
   describe "#due_on" do
-    subject { policy.due_on }
+    subject { policy.send :due_on }
 
     context "when configured to be valid for 60 days" do
       let(:valid_for_n_days) { 60 }
 
       context "and was checked 70 days ago" do
-        let(:check) { create_check(last_check_date: 70.days.ago) }
+        let!(:check) { create(:project_check, last_check_date: 70.days.ago, reminder: reminder) }
 
         it { is_expected.to eq(10.days.ago.to_date) }
 
         context "and was disabled for 20 days" do
-          before { disable_check_for(20.days) }
+          include_context "check disabled for duration", 20.days
 
           it { is_expected.to eq(10.days.from_now.to_date) }
         end
@@ -53,12 +79,12 @@ describe DueDatePolicy do
       let(:init_valid_for_n_days) { 10 }
 
       context "and was created 15 days ago and never checked" do
-        let(:check) { create_check(created_at: 15.days.ago) }
+        let!(:check) { create(:project_check, created_at: 15.days.ago, reminder: reminder) }
 
         it { is_expected.to eq(5.days.ago.to_date) }
 
         context "and was disabled for 7 days" do
-          before { disable_check_for(7.days) }
+          include_context "check disabled for duration", 7.days
 
           it { is_expected.to eq(2.days.from_now.to_date) }
         end
@@ -67,56 +93,40 @@ describe DueDatePolicy do
   end
 
   describe "#due_in" do
-    it "returns the difference between today and due date in days" do
-      allow(subject).to receive(:due_on).and_return(20.days.from_now.to_date)
-      expect(subject.due_in).to eq 20
-    end
-
-    it "is less than zero when overdue" do
-      allow(subject).to receive(:due_on).and_return(20.days.ago.to_date)
-      expect(subject.due_in).to eq(-20)
-    end
-
-    it "equals zero if due today" do
-      allow(subject).to receive(:due_on).and_return(Time.zone.today.to_date)
-      expect(subject.due_in).to eq(0)
-    end
+    subject { policy.due_in }
+    include_examples "due date is in the past/the future/today",
+                     20.days,
+                     future: 20,
+                     past: -20,
+                     today: 0
   end
 
   describe "#overdue?" do
-    it "is true if due date is in the past" do
-      allow(subject).to receive(:due_on).and_return(20.days.ago.to_date)
-      expect(subject.overdue?).to eq(true)
-    end
-
-    it "is false if due date is in the future" do
-      allow(subject).to receive(:due_on).and_return(20.days.from_now.to_date)
-      expect(subject.overdue?).to eq(false)
-    end
-
-    it "is false if due today" do
-      allow(subject).to receive(:due_on).and_return(Time.zone.today.to_date)
-      expect(subject.overdue?).to eq(false)
-    end
+    subject { policy.overdue? }
+    include_examples "due date is in the past/the future/today",
+                     20.days,
+                     future: false,
+                     past: true,
+                     today: false
   end
 
   describe "#remind_on" do
-    subject { policy.remind_on }
+    subject { policy.send :remind_on }
     let(:remind_after_days) { [5, 30, 45] }
     let(:init_remind_after_days) { [2, 6, 8] }
 
     context "when never checked" do
-      let(:check) { create_check(created_at: 4.days.ago) }
+      let!(:check) { create(:project_check, created_at: 4.days.ago, reminder: reminder) }
 
       it "calculates notification dates from created_at" do
-        expect(subject).to eq([2.days.ago,
-                               2.days.from_now,
-                               4.days.from_now].map(&:to_date))
+        is_expected.to eq([2.days.ago,
+                           2.days.from_now,
+                           4.days.from_now].map(&:to_date))
       end
     end
 
     context "when checked before" do
-      let(:check) { create_check(last_check_date: 30.days.ago) }
+      let!(:check) { create(:project_check, last_check_date: 30.days.ago, reminder: reminder) }
 
       it "calculates notification dates from last_check_date" do
         expect(subject).to eq([25.days.ago,
@@ -126,8 +136,8 @@ describe DueDatePolicy do
     end
 
     context "when disabled for a period of time" do
-      let(:check) { create_check(last_check_date: 40.days.ago) }
-      before { disable_check_for(10.days) }
+      let!(:check) { create(:project_check, last_check_date: 40.days.ago, reminder: reminder) }
+      include_context "check disabled for duration", 10.days
 
       it "includes the disabled period in calculations" do
         expect(subject).to eq([25.days.ago,
@@ -138,32 +148,41 @@ describe DueDatePolicy do
   end
 
   describe "#remind_on?" do
-    it "checks if a reminder should be sent on given date" do
-      allow(subject).to receive(:remind_on)
+    before do
+      allow(policy).to receive(:remind_on)
         .and_return([5.days.from_now.to_date, 15.days.from_now.to_date])
+    end
 
-      expect(subject.remind_on?(5.days.from_now)).to eq true
-      expect(subject.remind_on?(10.days.from_now)).to eq false
+    context "if reminder should be sent on given date" do
+      subject { policy.send(:remind_on?, 5.days.from_now) }
+
+      it { is_expected.to be true }
+    end
+
+    context "if reminder shouldn't be sent on given date" do
+      subject { policy.send(:remind_on?, 10.days.from_now) }
+
+      it { is_expected.to be false }
     end
   end
 
   describe "#remind_today?" do
-    context "if reminder should be sent today" do
-      it "returns true" do
-        allow(subject).to receive(:remind_on)
-          .and_return([Time.zone.today.to_date])
+    subject { policy.remind_today? }
+    before do
+      allow(policy).to receive(:remind_on)
+        .and_return(remind_on_dates)
+    end
 
-        expect(subject.remind_today?).to eq true
-      end
+    context "if reminder should be sent today" do
+      let(:remind_on_dates) { [Time.zone.today.to_date] }
+
+      it { is_expected.to be true }
     end
 
     context "if reminder shouldn't be sent today" do
-      it "returns true" do
-        allow(subject).to receive(:remind_on)
-          .and_return([10.days.from_now.to_date])
+      let(:remind_on_dates) { [10.days.from_now.to_date] }
 
-        expect(subject.remind_today?).to eq false
-      end
+      it { is_expected.to be false }
     end
   end
 
@@ -172,6 +191,7 @@ describe DueDatePolicy do
 
     context "when never checked" do
       let(:check) { create_check(created_at: 40.days.ago) }
+      let!(:check) { create(:project_check, created_at: 40.days.ago, reminder: reminder) }
 
       it "calculates how many days have passed since created" do
         expect(subject).to eq(40)
@@ -179,19 +199,18 @@ describe DueDatePolicy do
     end
 
     context "when checked before" do
-      let(:check) { create_check(last_check_date: 30.days.ago) }
+      let!(:check) { create(:project_check, last_check_date: 30.days.ago, reminder: reminder) }
 
       it "calculates how many days have passed since last check" do
         expect(subject).to eq(30)
       end
-    end
 
-    context "when disabled for a period of time" do
-      let(:check) { create_check(last_check_date: 30.days.ago) }
-      before { disable_check_for(10.days) }
+      context "and disabled for a period of time" do
+        include_context "check disabled for duration", 10.days
 
-      it "it includes the disabled period in calculations" do
-        expect(subject).to eq(20)
+        it "it includes the disabled period in calculations" do
+          expect(subject).to eq(20)
+        end
       end
     end
   end

--- a/spec/policies/due_date_policy_spec.rb
+++ b/spec/policies/due_date_policy_spec.rb
@@ -1,0 +1,122 @@
+require "rails_helper"
+
+describe DueDatePolicy do
+  subject { described_class.new(check) }
+  let(:check) { create(:project_check) }
+
+  def create_check(attrs = {})
+    create(:project_check, attrs.merge(reminder: reminder))
+  end
+
+  def disable_check_for(duration)
+    repo = ProjectChecksRepository.new
+    repo.update(check, enabled: false)
+    check.update disabled_date: duration.ago
+    repo.update(check, enabled: true)
+    return check
+  end
+
+  it { is_expected.to respond_to(:project_check) }
+  it { is_expected.to delegate_method(:reminder).to(:project_check) }
+
+  describe "#due_on" do
+    context "when configured to be valid for 60 days" do
+      subject { described_class.new(check).due_on }
+      let(:reminder) { create(:reminder, valid_for_n_days: 60) }
+
+      context "and was checked 70 days ago" do
+        let(:check) { create_check(last_check_date: 70.days.ago) }
+
+        it { is_expected.to eq(10.days.ago.to_date) }
+
+        context "and was disabled for 20 days" do
+          before { disable_check_for(20.days) }
+
+          it { is_expected.to eq(10.days.from_now.to_date) }
+        end
+      end
+
+      context "and was created 70 days ago and never checked" do
+        let(:check) { create_check(created_at: 70.days.ago) }
+
+        it { is_expected.to eq(10.days.ago.to_date) }
+
+        context "and was disabled for 20 days" do
+          before { disable_check_for(20.days) }
+
+          it { is_expected.to eq(10.days.from_now.to_date) }
+        end
+      end
+    end
+  end
+
+  describe "#due_in" do
+    it "returns the difference between today and due date in days" do
+      allow(subject).to receive(:due_on).and_return(20.days.from_now.to_date)
+      expect(subject.due_in).to eq 20
+    end
+
+    it "is less than zero when overdue" do
+      allow(subject).to receive(:due_on).and_return(20.days.ago.to_date)
+      expect(subject.due_in).to eq(-20)
+    end
+
+    it "equals zero if due today" do
+      allow(subject).to receive(:due_on).and_return(Time.zone.today.to_date)
+      expect(subject.due_in).to eq(0)
+    end
+  end
+
+  describe "#overdue?" do
+    it "is true if due date is in the past" do
+      allow(subject).to receive(:due_on).and_return(20.days.ago.to_date)
+      expect(subject.overdue?).to eq(true)
+    end
+
+    it "is false if due date is in the future" do
+      allow(subject).to receive(:due_on).and_return(20.days.from_now.to_date)
+      expect(subject.overdue?).to eq(false)
+    end
+
+    it "is false if due today" do
+      allow(subject).to receive(:due_on).and_return(Time.zone.today.to_date)
+      expect(subject.overdue?).to eq(false)
+    end
+  end
+
+  describe "#remind_on" do
+    subject { described_class.new(check).remind_on }
+    let(:reminder) { create(:reminder, remind_after_days: [5, 30, 45]) }
+
+    context "when never checked" do
+      let(:check) { create_check(created_at: 40.days.ago) }
+
+      it "calculates notification dates from created_at" do
+        expect(subject).to eq([35.days.ago,
+                               10.days.ago,
+                               5.days.from_now,].map(&:to_date))
+      end
+    end
+
+    context "when checked before" do
+      let(:check) { create_check(last_check_date: 30.days.ago) }
+
+      it "calculates notification dates from last_check_date" do
+        expect(subject).to eq([25.days.ago,
+                               Time.zone.today,
+                               15.days.from_now,].map(&:to_date))
+      end
+    end
+
+    context "when disabled for a period of time" do
+      let(:check) { create_check(last_check_date: 40.days.ago) }
+      before { disable_check_for(10.days) }
+
+      it "includes the disabled period in calculations" do
+        expect(subject).to eq([25.days.ago,
+                               Time.zone.today,
+                               15.days.from_now,].map(&:to_date))
+      end
+    end
+  end
+end

--- a/spec/repositories/project_checks_repository_spec.rb
+++ b/spec/repositories/project_checks_repository_spec.rb
@@ -72,8 +72,7 @@ describe ProjectChecksRepository do
 
   describe "#update" do
     let(:project_check) { create(:project_check) }
-    before { Timecop.freeze }
-    after { Timecop.return }
+    include_context "time frozen"
 
     it "updates given project check" do
       expect(project_check.last_check_user_id).to be nil
@@ -87,20 +86,21 @@ describe ProjectChecksRepository do
 
       shared_examples "setting enabled to true" do
         context "when you set enabled to true" do
-          it "calculates the last_check_date_without_disabled_period" do
+          before do
             repo.update(project_check, enabled: true)
+          end
+
+          it "calculates the last_check_date_without_disabled_period" do
             expect(project_check.last_check_date_without_disabled_period)
               .to eq(expected_last_check_date_without_disabled_period.try(:to_date))
           end
 
           it "calculates the created_at_without_disabled_period" do
-            repo.update(project_check, enabled: true)
             expect(project_check.created_at_without_disabled_period)
               .to eq(expected_created_at_without_disabled_period.try(:to_datetime))
           end
 
           it "sets disabled_date to nil" do
-            repo.update(project_check, enabled: true)
             expect(project_check.disabled_date).to eq(nil)
           end
         end

--- a/spec/repositories/project_checks_repository_spec.rb
+++ b/spec/repositories/project_checks_repository_spec.rb
@@ -83,7 +83,7 @@ describe ProjectChecksRepository do
       let(:attrs) { {} }
       let(:project_check) { create(:project_check, attrs) }
 
-      shared_examples "setting enabled to true" do |expected_date|
+      shared_examples "setting enabled to true" do
         context "when you set enabled to true" do
           it "calculates the last_check_date_without_disabled_period" do
             repo.update(project_check, enabled: true)
@@ -104,8 +104,9 @@ describe ProjectChecksRepository do
             enabled: false,
             last_check_date: 3.weeks.ago }
         end
+        let(:expected_date) { 1.week.ago }
 
-        include_examples "setting enabled to true", 1.week.ago
+        include_examples "setting enabled to true"
       end
 
       context "that was disabled and enabled before" do
@@ -115,8 +116,9 @@ describe ProjectChecksRepository do
             disabled_date: 1.week.ago,
             enabled: false }
         end
+        let(:expected_date) { 3.weeks.ago }
 
-        include_examples "setting enabled to true", 3.weeks.ago
+        include_examples "setting enabled to true"
       end
 
       context "that was never checked" do
@@ -125,8 +127,9 @@ describe ProjectChecksRepository do
             disabled_date: 1.week.ago,
             enabled: false }
         end
+        let(:expected_date) { nil }
 
-        include_examples "setting enabled to true", nil
+        include_examples "setting enabled to true"
 
         it "moves created_at forward by the disabled period duration" do
           repo.update(project_check, enabled: true)

--- a/spec/repositories/project_checks_repository_spec.rb
+++ b/spec/repositories/project_checks_repository_spec.rb
@@ -73,6 +73,7 @@ describe ProjectChecksRepository do
   describe "#update" do
     let(:project_check) { create(:project_check) }
     before { Timecop.freeze }
+    after { Timecop.return }
 
     it "updates given project check" do
       expect(project_check.last_check_user_id).to be nil

--- a/spec/support/pages/reminders/sections/project_checks_table_row.rb
+++ b/spec/support/pages/reminders/sections/project_checks_table_row.rb
@@ -3,11 +3,12 @@ require_relative "../sections/project_checks_history_table.rb"
 module Reminders
   class ProjectChecksTableRow < SitePrism::Section
     element :project, "td:first"
-    element :last_check_date, "td[2]"
-    element :last_checker, "td[4]"
-    element :history_button, "td[5]"
-    element :check_button, "td[6] button"
-    element :toggle_state_button, ".toggle-state a"
+    element :last_check_date, "td:nth-child(2)"
+    element :days_to_deadline, "td:nth-child(3)"
+    element :last_checker, "td:nth-child(5)"
+    element :history_button, "td:nth-child(6)"
+    element :complete_check_link, "td:nth-child(7) a"
+    element :toggle_state_button, ".toggle-state form"
     element :assigned_reviewer, ".assigned-person"
     element :pick_random_button, ".pick-random-button"
     element :reassign_random_button, ".reassign-random-button"
@@ -21,6 +22,20 @@ module Reminders
 
     def disabled?
       evaluate_script("$('.toggle-switch').attr('checked')").nil?
+    end
+
+    def deadline_input
+      days_to_deadline.find('input#project_check_days_left')
+    end
+
+    def mark_as_checked!
+      complete_check_link.click
+      fill_in("Note url", with: "http://example.com")
+      click_button("Add a note URL and mark as done")
+    end
+
+    def toggle_state!
+      toggle_state_button.click
     end
   end
 end

--- a/spec/support/pages/reminders/sections/project_checks_table_row.rb
+++ b/spec/support/pages/reminders/sections/project_checks_table_row.rb
@@ -4,7 +4,10 @@ module Reminders
   class ProjectChecksTableRow < SitePrism::Section
     element :project, "td:first"
     element :last_check_date, "td:nth-child(2)"
-    element :days_to_deadline, "td:nth-child(3)"
+    section :deadline, "td:nth-child(3)" do
+      element :input, "input#project_check_days_left"
+      delegate :text, to: :root_element
+    end
     element :last_checker, "td:nth-child(5)"
     element :history_button, "td:nth-child(6)"
     element :complete_check_link, "td:nth-child(7) a"
@@ -22,10 +25,6 @@ module Reminders
 
     def disabled?
       evaluate_script("$('.toggle-switch').attr('checked')").nil?
-    end
-
-    def deadline_input
-      days_to_deadline.find("input#project_check_days_left")
     end
 
     def mark_as_checked!

--- a/spec/support/pages/reminders/sections/project_checks_table_row.rb
+++ b/spec/support/pages/reminders/sections/project_checks_table_row.rb
@@ -25,7 +25,7 @@ module Reminders
     end
 
     def deadline_input
-      days_to_deadline.find('input#project_check_days_left')
+      days_to_deadline.find("input#project_check_days_left")
     end
 
     def mark_as_checked!

--- a/spec/support/shared_contexts/time_frozen.rb
+++ b/spec/support/shared_contexts/time_frozen.rb
@@ -1,0 +1,7 @@
+shared_context "time frozen" do |time = nil|
+  around do |example|
+    Timecop.freeze(time)
+    example.run
+    Timecop.return
+  end
+end

--- a/spec/use_cases/project_checks/override_deadline_spec.rb
+++ b/spec/use_cases/project_checks/override_deadline_spec.rb
@@ -17,10 +17,10 @@ describe ProjectChecks::OverrideDeadline do
 
   describe "#call" do
     context "when new days changed" do
-      it "updates project check created at field" do
+      it "updates project check created_at_without_disabled_period field" do
         Timecop.freeze(Time.zone.today - valid_for_n_days.days) do
-          expect { subject }.to change { check.created_at }
-            .from(Time.current)
+          expect { subject }.to change { check.created_at_without_disabled_period }
+            .from(nil)
             .to(Time.current + 10.days)
         end
       end


### PR DESCRIPTION
## Ticket
https://netguru.atlassian.net/browse/RD-97

## Description
- All logic related to project check deadlines now lives in `DueDatePolicy`
- The policy object has tests for edge cases
- A feature spec for due dates was added to make sure the policy object is used properly
- Enabling/disabling a project check and overriding its deadline no longer change the `created_at` column.