### PR TITLE
Fixes jira issues query to use without_disabled_period

### DIFF
--- a/app/queries/project_checks/requiring_jira_issues_query.rb
+++ b/app/queries/project_checks/requiring_jira_issues_query.rb
@@ -25,9 +25,9 @@ module ProjectChecks
           AND '#{date}' >= (date(project_checks.created_at) + reminders.init_valid_for_n_days
                           - reminders.jira_issue_lead))
         OR
-        (last_check_date IS NOT NULL
-          AND '#{date}' >= (date(last_check_date) + reminders.valid_for_n_days
-                          - reminders.jira_issue_lead))
+        ((last_check_date IS NOT NULL OR last_check_date_without_disabled_period IS NOT NULL)
+          AND '#{date}' >= (GREATEST(last_check_date, last_check_date_without_disabled_period)
+                           + reminders.valid_for_n_days - reminders.jira_issue_lead))
       SQL
     end
   end

--- a/spec/queries/project_checks/requiring_jira_issues_query_spec.rb
+++ b/spec/queries/project_checks/requiring_jira_issues_query_spec.rb
@@ -131,5 +131,38 @@ describe ProjectChecks::RequiringJiraIssuesQuery do
         end
       end
     end
+
+    context "when issue has been disabled for some time" do
+      context "when jira task should be created" do
+        let(:last_check_date) { Time.zone.today - 123.days }
+
+        let!(:project_2_check) do
+          create(:project_check,
+                 project: project_2,
+                 reminder: reminder,
+                 last_check_date: last_check_date,
+                 last_check_date_without_disabled_period: Time.zone.today - 23.days)
+        end
+
+        it "returns 1 projeck check" do
+          expect(subject.count).to eq(1)
+          expect(subject.first).to eq(project_2_check)
+        end
+      end
+
+      context "when jira issue should not be created" do
+        let(:last_check_date) { Time.zone.today - 23.days }
+
+        let!(:project_2_check) do
+          create(:project_check,
+                 project: project_2,
+                 reminder: reminder,
+                 last_check_date: last_check_date,
+                 last_check_date_without_disabled_period: Time.zone.today - 22.days)
+        end
+
+        it_behaves_like "no project checks"
+      end
+    end
   end
 end

--- a/spec/queries/project_checks/requiring_jira_issues_query_spec.rb
+++ b/spec/queries/project_checks/requiring_jira_issues_query_spec.rb
@@ -144,7 +144,7 @@ describe ProjectChecks::RequiringJiraIssuesQuery do
                  last_check_date_without_disabled_period: Time.zone.today - 23.days)
         end
 
-        it "returns 1 projeck check" do
+        it "returns 1 project check" do
           expect(subject.count).to eq(1)
           expect(subject.first).to eq(project_2_check)
         end


### PR DESCRIPTION
## Description
* jira issues query now takes `last_check_date_without_disabled_period` into consideration.

## Ticket
https://netguru.atlassian.net/browse/RD-103