### PR TITLE
RMD-25

### DIFF
--- a/app/controllers/reminders_controller.rb
+++ b/app/controllers/reminders_controller.rb
@@ -82,6 +82,6 @@ class RemindersController < ApplicationController
                   :notification_text, :deadline_text, :slack_channel,
                   :supervisor_slack_channel, :notify_projects_channels,
                   :jira_issue_lead, :init_valid_for_n_days, :init_remind_after_days,
-                  :init_deadline_text, :init_notification_text)
+                  :init_deadline_text, :init_notification_text, :jira_project_key)
   end
 end

--- a/app/decorators/reminder_decorator/base.rb
+++ b/app/decorators/reminder_decorator/base.rb
@@ -2,7 +2,8 @@ module ReminderDecorator
   class Base < BaseDecorator
     delegate :id, :name, :valid_for_n_days, :deadline_text, :notification_text,
              :persisted?, :slack_channel, :supervisor_slack_channel, :notify_projects_channels,
-             :jira_issue_lead, :init_valid_for_n_days, :init_deadline_text, :init_notification_text
+             :jira_issue_lead, :init_valid_for_n_days, :init_deadline_text, :init_notification_text,
+             :jira_project_key
     decorates :reminder
 
     def init_remind_after_days

--- a/app/jobs/create_jira_issues_job.rb
+++ b/app/jobs/create_jira_issues_job.rb
@@ -7,7 +7,7 @@ class CreateJiraIssuesJob
 
   def perform
     project_checks.each do |check|
-      issue = Jira.create_issue_from_project(project: check.project)
+      issue = Jira.create_issue_from_project(project: check.project, reminder: check.reminder)
       if issue.is_a?(Hash) && issue.key?("key")
         check.update_columns(jira_issue_key: issue["key"], jira_issue_created_at: Time.zone.now)
       end

--- a/app/models/jira.rb
+++ b/app/models/jira.rb
@@ -45,7 +45,6 @@ class Jira
   end
 
   def jira_project_key
-    binding.pry
     @jira_project_key ||= options.fetch(:reminder).jira_project_key || settings.project_key
   end
 

--- a/app/models/jira.rb
+++ b/app/models/jira.rb
@@ -1,7 +1,7 @@
 class Jira
   class << self
-    def create_issue_from_project(project:)
-      new(project: project).create_issue_from_project
+    def create_issue_from_project(project:, reminder:)
+      new(project: project, reminder: reminder).create_issue_from_project
     end
   end
 
@@ -33,7 +33,7 @@ class Jira
   def jira_params
     {
       fields: {
-        project: { key: settings.project_key },
+        project: { key: jira_project_key },
         issuetype: { name: settings.issue_type },
         summary: "#{settings.summary} #{options.fetch(:project).name}",
       },
@@ -42,6 +42,10 @@ class Jira
 
   def settings
     @settings ||= AppConfig.jira
+  end
+
+  def jira_project_key
+    @jira_project_key ||= options.fetch(:reminder).jira_project_key || settings.jira_project_key
   end
 
   def headers

--- a/app/models/jira.rb
+++ b/app/models/jira.rb
@@ -45,7 +45,8 @@ class Jira
   end
 
   def jira_project_key
-    @jira_project_key ||= options.fetch(:reminder).jira_project_key || settings.jira_project_key
+    binding.pry
+    @jira_project_key ||= options.fetch(:reminder).jira_project_key || settings.project_key
   end
 
   def headers

--- a/app/views/reminders/_form.slim
+++ b/app/views/reminders/_form.slim
@@ -23,6 +23,7 @@
         = f.input :notify_projects_channels, as: :boolean
         = f.input :supervisor_slack_channel, required: false
         = f.input :jira_issue_lead, required: false
+        = f.input :jira_project_key
 
       .form-actions
         = f.button :submit

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,7 @@ en:
         jira_issue_lead: >
           How many days before check day, should jira issue be created.
           Leave blank to disable issue creation
+        jira_project_key: If not specified, jira issue will be created in RND project.
   project_checks:
     not_checked_yet: not checked yet
   reminders:

--- a/db/migrate/20170505121138_add_jira_project_key_to_reminders.rb
+++ b/db/migrate/20170505121138_add_jira_project_key_to_reminders.rb
@@ -1,0 +1,5 @@
+class AddJiraProjectKeyToReminders < ActiveRecord::Migration[5.0]
+  def change
+    add_column :reminders, :jira_project_key, :string  
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170329095336) do
+ActiveRecord::Schema.define(version: 20170505121138) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,6 +84,7 @@ ActiveRecord::Schema.define(version: 20170329095336) do
     t.text     "init_deadline_text"
     t.text     "init_notification_text"
     t.integer  "order",                    default: 0
+    t.string   "jira_project_key"
   end
 
   create_table "skills", force: :cascade do |t|

--- a/spec/jobs/create_jira_issues_job_spec.rb
+++ b/spec/jobs/create_jira_issues_job_spec.rb
@@ -29,7 +29,7 @@ describe CreateJiraIssuesJob do
 
     context "when there is 1 project check requiring jira issue" do
       let(:project) { double :project, name: "Project 1" }
-      let(:reminder) { double :reminder, jira_project_key: "RDM"}
+      let(:reminder) { double :reminder, jira_project_key: "RDM" }
       let(:project_check) { double :project_check, id: 3, project: project, reminder: reminder }
       let(:zone) { ActiveSupport::TimeZone.new("Kuwait") }
       let(:time) { zone.now }
@@ -41,7 +41,8 @@ describe CreateJiraIssuesJob do
       end
 
       it "creates 1 jira issue" do
-        expect(Jira).to receive(:create_issue_from_project).once.with(project: project, reminder: reminder)
+        expect(Jira).to receive(:create_issue_from_project)
+          .once.with(project: project, reminder: reminder)
         expect(subject).to eq([project_check])
       end
 

--- a/spec/jobs/create_jira_issues_job_spec.rb
+++ b/spec/jobs/create_jira_issues_job_spec.rb
@@ -29,7 +29,7 @@ describe CreateJiraIssuesJob do
 
     context "when there is 1 project check requiring jira issue" do
       let(:project) { double :project, name: "Project 1" }
-      let(:reminder) { double :reminder, jira_project_key: "RDM" }
+      let(:reminder) { double :reminder, jira_project_key: "AAA" }
       let(:project_check) { double :project_check, id: 3, project: project, reminder: reminder }
       let(:zone) { ActiveSupport::TimeZone.new("Kuwait") }
       let(:time) { zone.now }

--- a/spec/jobs/create_jira_issues_job_spec.rb
+++ b/spec/jobs/create_jira_issues_job_spec.rb
@@ -29,7 +29,8 @@ describe CreateJiraIssuesJob do
 
     context "when there is 1 project check requiring jira issue" do
       let(:project) { double :project, name: "Project 1" }
-      let(:project_check) { double :project_check, id: 3, project: project }
+      let(:reminder) { double :reminder, jira_project_key: "RDM"}
+      let(:project_check) { double :project_check, id: 3, project: project, reminder: reminder }
       let(:zone) { ActiveSupport::TimeZone.new("Kuwait") }
       let(:time) { zone.now }
 
@@ -40,7 +41,7 @@ describe CreateJiraIssuesJob do
       end
 
       it "creates 1 jira issue" do
-        expect(Jira).to receive(:create_issue_from_project).once.with(project: project)
+        expect(Jira).to receive(:create_issue_from_project).once.with(project: project, reminder: reminder)
         expect(subject).to eq([project_check])
       end
 
@@ -48,7 +49,7 @@ describe CreateJiraIssuesJob do
         expect(Time).to receive(:zone).and_return(zone)
         expect(zone).to receive(:now).and_return(time)
         expect(Jira).to receive(:create_issue_from_project)
-          .once.with(project: project).and_return("key" => "RD-X")
+          .once.with(project: project, reminder: reminder).and_return("key" => "RD-X")
         expect(project_check).to receive(:update_columns)
           .with(jira_issue_key: "RD-X", jira_issue_created_at: time)
         expect(subject).to eq([project_check])

--- a/spec/models/jira_spec.rb
+++ b/spec/models/jira_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Jira do
     let(:response) { double :response, body: { key: "RD-X" }.to_json, code: 201 }
     let(:jira_username) { "jira_user" }
     let(:jira_password) { "jira_pass" }
-    let(:jira_project_key) { "JRX" }
+    let(:jira_project_key) { "AAA" }
     let(:authorization) { "Basic #{Base64.strict_encode64("#{jira_username}:#{jira_password}")}" }
 
     let(:params) do
@@ -68,7 +68,7 @@ RSpec.describe Jira do
       end
 
       context "when jira_project_key is set in reminder" do
-        let(:reminder) { double :reminder, jira_project_key: "RMD" }
+        let(:reminder) { double :reminder, jira_project_key: "BBB" }
         let(:params) do
           {
             fields: {

--- a/spec/models/jira_spec.rb
+++ b/spec/models/jira_spec.rb
@@ -7,7 +7,10 @@ RSpec.describe Jira do
 
   describe ".create_issue_from_project" do
     it "creates instance and calls create_issue_from_project method" do
-      expect(described_class).to receive(:new).with(project: project, reminder: reminder).and_return(jira)
+      expect(described_class).to receive(:new)
+        .with(project: project,
+              reminder: reminder)
+        .and_return(jira)
       expect_any_instance_of(described_class).to receive(:create_issue_from_project).with(no_args)
       described_class.create_issue_from_project(project: project, reminder: reminder)
     end

--- a/spec/models/jira_spec.rb
+++ b/spec/models/jira_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Jira do
   let(:project) { double :project, id: 3, name: "Unique project" }
   let(:reminder) { double :reminder, jira_project_key: nil }
-  let(:jira) { Jira.new(project: project, reminder: reminder) }
+  let(:jira) { described_class.new(project: project, reminder: reminder) }
 
   describe ".create_issue_from_project" do
     it "creates instance and calls create_issue_from_project method" do

--- a/spec/models/jira_spec.rb
+++ b/spec/models/jira_spec.rb
@@ -2,13 +2,14 @@ require "rails_helper"
 
 RSpec.describe Jira do
   let(:project) { double :project, id: 3, name: "Unique project" }
-  let(:jira) { Jira.new(project: project) }
+  let(:reminder) { double :reminder, jira_project_key: nil }
+  let(:jira) { Jira.new(project: project, reminder: reminder) }
 
   describe ".create_issue_from_project" do
     it "creates instance and calls create_issue_from_project method" do
-      expect(described_class).to receive(:new).with(project: project).and_return(jira)
+      expect(described_class).to receive(:new).with(project: project, reminder: reminder).and_return(jira)
       expect_any_instance_of(described_class).to receive(:create_issue_from_project).with(no_args)
-      described_class.create_issue_from_project(project: project)
+      described_class.create_issue_from_project(project: project, reminder: reminder)
     end
   end
 
@@ -20,6 +21,7 @@ RSpec.describe Jira do
     let(:response) { double :response, body: { key: "RD-X" }.to_json, code: 201 }
     let(:jira_username) { "jira_user" }
     let(:jira_password) { "jira_pass" }
+    let(:jira_project_key) { "JRX" }
     let(:authorization) { "Basic #{Base64.strict_encode64("#{jira_username}:#{jira_password}")}" }
 
     let(:params) do
@@ -43,6 +45,7 @@ RSpec.describe Jira do
       around do |example|
         AppConfig["jira"]["username"] = jira_username
         AppConfig["jira"]["password"] = jira_password
+        AppConfig["jira"]["project_key"] = jira_project_key
 
         previous = AppConfig["jira"]["enabled?"]
         AppConfig["jira"]["enabled?"] = true
@@ -52,11 +55,31 @@ RSpec.describe Jira do
         AppConfig["jira"]["password"] = nil
       end
 
-      it "sends request to jira endpoint and returns parsed response" do
-        expect(RestClient).to receive(:post)
-          .with("#{endpoint}/issue", params.to_json, headers)
-          .and_return(response)
-        expect(subject).to eq("key" => "RD-X")
+      shared_examples "sends request to jira endpoint and returns parsed response" do
+        it "sends request to jira endpoint and returns parsed response" do
+          expect(RestClient).to receive(:post)
+            .with("#{endpoint}/issue", params.to_json, headers)
+            .and_return(response)
+          expect(subject).to eq("key" => "RD-X")
+        end
+      end
+
+      context "when jira_project_key is set in reminder" do
+        let(:reminder) { double :reminder, jira_project_key: "RMD" }
+        let(:params) do
+          {
+            fields: {
+              project: { key: reminder.jira_project_key },
+              issuetype: { name: config.issue_type },
+              summary: "#{config.summary} #{project.name}",
+            },
+          }
+        end
+        include_examples "sends request to jira endpoint and returns parsed response"
+      end
+
+      context "when jira_project_key is not set in reminder" do
+        include_examples "sends request to jira endpoint and returns parsed response"
       end
     end
 


### PR DESCRIPTION
This PR gives users ability to choose in which JIRA project issue will be created. So far all issues were created in RND project. After this change users can specify `jira_project_key` in each reminder where issue should appear. If user does not specify this field and jira issue is set to be created, app will use default value which is defined in `config.yml`.