### PR TITLE
RMD-27

### DIFF
--- a/app/models/notifier.rb
+++ b/app/models/notifier.rb
@@ -23,9 +23,9 @@ class Notifier
           notifier_message(message: message, channel: "##{channel}"),
         )
       elsif channel_changed_name?(channel)
-        channel = get_channel_id(channel)
+        channel_id = get_channel_id(channel)
         responses << client.chat_postMessage(
-          notifier_message(message: message, channel: "#{channel}"),
+          notifier_message(message: message, channel: channel_id),
         )
       end
     end

--- a/app/models/notifier.rb
+++ b/app/models/notifier.rb
@@ -50,12 +50,12 @@ class Notifier
     }
   end
 
-  def channel_exists?(name)
-    channels_list.select { |c| c["name"] == name }.any?
-  end
-
   def channels_list
     @channels_list ||= client.channels_list["channels"]
+  end
+
+  def channel_exists?(name)
+    channels_list.select { |c| c["name"] == name }.any?
   end
 
   def channel_changed_name?(name)

--- a/spec/models/notifier_spec.rb
+++ b/spec/models/notifier_spec.rb
@@ -37,7 +37,7 @@ describe Notifier do
 
     context "when options contain one channel" do
       context "when channel provided as array with one item" do
-        let(:options) { { channels: %w[chan] } }
+        let(:options) { { channels: %w(chan) } }
 
         it "sends one message to client" do
           expect(client).to receive(:chat_postMessage)
@@ -61,7 +61,7 @@ describe Notifier do
 
     context "when options contain 3 channels" do
       context "when channels provided as array with three items" do
-        let(:options) { { channels: %w[chan1 chan2 chan3] } }
+        let(:options) { { channels: %w(chan1 chan2 chan3) } }
 
         it "sends 3 messages to client" do
           expect(client).to receive(:chat_postMessage)
@@ -127,7 +127,7 @@ describe Notifier do
       end
 
       context "when channel provided as array with one item" do
-        let(:options) { { channels: %w[old_name] } }
+        let(:options) { { channels: %w(old_name) } }
 
         it "sends one message to client using ID of channel" do
           expect(client).to receive(:chat_postMessage)
@@ -149,7 +149,7 @@ describe Notifier do
       end
 
       context "when channel provided as array with one item" do
-        let(:options) { { channels: %w[non_existing_channel] } }
+        let(:options) { { channels: %w(non_existing_channel) } }
 
         it "does not send any messages" do
           expect(client).not_to receive(:any)


### PR DESCRIPTION
When slack channel name was changed, app uses ID of slack channel instead of name. This PR does this thing.